### PR TITLE
Return the XHR deferred object from the request

### DIFF
--- a/curious.js
+++ b/curious.js
@@ -182,7 +182,7 @@
         if (trees_cb) { trees_cb(res.trees); }
       };
 
-      http.post(curious_url, args).success(post_cb);
+      return http.post(curious_url, args).success(post_cb);
     }
 
     function get(q, relationships, cb, params, tree_cb) { __get(q, params, relationships, null, cb, tree_cb); }


### PR DESCRIPTION
This allows consumers of curious to add their own success or failure callbacks, which is very useful. In general, I think we should be doing this so that it can work with jQuery Deferred objects, rather than CuriousXHRs.
