### PR TITLE
Default parameter for performQuery relationships

### DIFF
--- a/curious.js
+++ b/curious.js
@@ -1091,6 +1091,7 @@
        */
       performQuery: function (q, relationships, constructors, params, existingObjects) {
         var args;
+        relationships = relationships || [];
 
         if (!quiet) {
           console.info(q);


### PR DESCRIPTION
Currently, queries without a relationship will throw an error. This fixes this by providing the default parameter.
